### PR TITLE
That changeset from before, with the right line endings!

### DIFF
--- a/Rhino.Etl.Core/Enumerables/GatedThreadSafeEnumerator.cs
+++ b/Rhino.Etl.Core/Enumerables/GatedThreadSafeEnumerator.cs
@@ -9,7 +9,7 @@ namespace Rhino.Etl.Core.Enumerables
 	/// An iterator to be consumed by concurrent threads only which supplies an element of the decorated enumerable one by one
 	/// </summary>
 	/// <typeparam name="T">The type of the decorated enumerable</typeparam>
-	internal class GatedThreadSafeEnumerator<T> : WithLoggingMixin, IEnumerable<T>, IEnumerator<T>
+	public class GatedThreadSafeEnumerator<T> :	WithLoggingMixin, IEnumerable<T>, IEnumerator<T>
 	{
 		private readonly int numberOfConsumers;
 		private readonly IEnumerator<T> innerEnumerator;
@@ -31,6 +31,10 @@ namespace Rhino.Etl.Core.Enumerables
 			innerEnumerator = source.GetEnumerator();
 		}
 
+		///	<summary>
+		///	Get	the	enumerator
+		///	</summary>
+		///	<returns></returns>
 		public IEnumerator<T> GetEnumerator()
 		{
 			return this;
@@ -41,6 +45,9 @@ namespace Rhino.Etl.Core.Enumerables
 			return GetEnumerator();
 		}
 
+		///	<summary>
+		///	Dispose	the	enumerator
+		///	</summary>
 		public void Dispose()
 		{
 			if(Interlocked.Decrement(ref consumersLeft) == 0)
@@ -50,6 +57,10 @@ namespace Rhino.Etl.Core.Enumerables
 			}
 		}
 
+		///	<summary>
+		///	MoveNext the enumerator
+		///	</summary>
+		///	<returns></returns>
 		public bool MoveNext()
 		{
 			lock (sync)
@@ -71,11 +82,17 @@ namespace Rhino.Etl.Core.Enumerables
 			return moveNext;
 		}
 
+		///	<summary>
+		///	Reset the enumerator
+		///	</summary>
 		public void Reset()
 		{
 			throw new NotSupportedException();
 		}
 
+		///	<summary>
+		///	The	current	value of the enumerator
+		///	</summary>
 		public T Current
 		{
 			get { return current; }
@@ -86,6 +103,9 @@ namespace Rhino.Etl.Core.Enumerables
 			get { return ((IEnumerator<T>)this).Current; }
 		}
 
+		///	<summary>
+		///	Number of consumers	left that have not yet completed
+		///	</summary>
 		public int ConsumersLeft { get { return consumersLeft; } }
 	}
 }

--- a/Rhino.Etl.Core/Operations/AbstractBranchingOperation.cs
+++ b/Rhino.Etl.Core/Operations/AbstractBranchingOperation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Rhino.Etl.Core.Operations
@@ -41,6 +42,44 @@ namespace Rhino.Etl.Core.Operations
 			foreach (IOperation operation in Operations)
 			{
 				operation.PrepareForExecution(pipelineExecuter);
+			}
+		}
+
+		///	<summary>
+		///	Occurs when	a row is processed.
+		///	</summary>
+		public override	event Action<IOperation, Row> OnRowProcessed
+		{
+			add
+			{
+				foreach	(IOperation	operation in Operations)
+					operation.OnRowProcessed +=	value;
+				base.OnRowProcessed	+= value;
+			}
+			remove
+			{
+				foreach	(IOperation	operation in Operations)
+					operation.OnRowProcessed -=	value;
+				base.OnRowProcessed	-= value;
+			}
+		}
+
+		///	<summary>
+		///	Occurs when	all	the	rows has finished processing.
+		///	</summary>
+		public override	event Action<IOperation> OnFinishedProcessing
+		{
+			add
+			{
+				foreach	(IOperation	operation in Operations)
+					operation.OnFinishedProcessing += value;
+				base.OnFinishedProcessing += value;
+			}
+			remove
+			{
+				foreach	(IOperation	operation in Operations)
+					operation.OnFinishedProcessing -= value;
+				base.OnFinishedProcessing -= value;
 			}
 		}
 	}

--- a/Rhino.Etl.Core/Operations/JoinOperation.cs
+++ b/Rhino.Etl.Core/Operations/JoinOperation.cs
@@ -271,5 +271,43 @@ namespace Rhino.Etl.Core.Operations
 				return this;
 			}
 		}
+
+		///	<summary>
+		///	Occurs when	a row is processed.
+		///	</summary>
+		public override	event Action<IOperation, Row> OnRowProcessed
+		{
+			add
+			{
+				foreach	(IOperation	operation in new[] { left, right })
+					operation.OnRowProcessed +=	value;
+				base.OnRowProcessed	+= value;
+			}
+			remove
+			{
+				foreach	(IOperation	operation in new[] { left, right })
+					operation.OnRowProcessed -=	value;
+				base.OnRowProcessed	-= value;
+			}
+		}
+
+		///	<summary>
+		///	Occurs when	all	the	rows has finished processing.
+		///	</summary>
+		public override	event Action<IOperation> OnFinishedProcessing
+		{
+			add
+			{
+				foreach	(IOperation	operation in new[] { left, right })
+					operation.OnFinishedProcessing += value;
+				base.OnFinishedProcessing += value;
+			}
+			remove
+			{
+				foreach	(IOperation	operation in new[] { left, right })
+					operation.OnFinishedProcessing -= value;
+				base.OnFinishedProcessing -= value;
+			}
+		}
 	}
 }

--- a/Rhino.Etl.Core/Operations/PartialProcessOperation.cs
+++ b/Rhino.Etl.Core/Operations/PartialProcessOperation.cs
@@ -40,8 +40,12 @@ namespace Rhino.Etl.Core.Operations
         /// <param name="pipelineExecuter">The current pipeline executer.</param>
         public void PrepareForExecution(IPipelineExecuter pipelineExecuter)
         {
+			this.pipelineExeuter =	pipelineExecuter;
+			foreach	(IOperation	operation in operations)
+			{
+				operation.PrepareForExecution(pipelineExecuter);
+			}
             Statistics.MarkStarted();
-            this.pipelineExeuter = pipelineExecuter;
         }
 
         /// <summary>

--- a/Rhino.Etl.Core/Operations/SqlBulkInsertOperation.cs
+++ b/Rhino.Etl.Core/Operations/SqlBulkInsertOperation.cs
@@ -30,6 +30,7 @@ namespace Rhino.Etl.Core.Operations
 		private string targetTable;
 		private int timeout;
         private int batchSize;
+		private	int	notifyBatchSize;
 		private SqlBulkCopyOptions bulkCopyOptions = SqlBulkCopyOptions.Default;
 		
 
@@ -96,6 +97,13 @@ namespace Rhino.Etl.Core.Operations
             get { return batchSize; }
             set { batchSize = value; }
         }
+
+		///	<summary>The batch size	value of the bulk insert operation</summary>
+		public virtual int NotifyBatchSize
+		{
+			get	{ return notifyBatchSize>0 ? notifyBatchSize : batchSize; }
+			set	{ notifyBatchSize =	value; }
+		}
 
 		/// <summary>The table or view to bulk load the data into.</summary>
 		public string TargetTable
@@ -249,6 +257,14 @@ namespace Rhino.Etl.Core.Operations
         }
 
 		/// <summary>
+		///	Handle sql notifications
+		///	</summary>
+		protected virtual void onSqlRowsCopied(object sender, SqlRowsCopiedEventArgs e)
+		{
+			Debug("{0} rows	copied to database", e.RowsCopied);
+		}
+
+		///	<summary>
 		/// Prepares the schema of the target table
 		/// </summary>
 		protected abstract void PrepareSchema();
@@ -264,6 +280,8 @@ namespace Rhino.Etl.Core.Operations
 			{
 				copy.ColumnMappings.Add(pair.Key, pair.Value);
 			}
+			copy.NotifyAfter = notifyBatchSize;
+			copy.SqlRowsCopied += onSqlRowsCopied;
 			copy.DestinationTableName = TargetTable;
 			copy.BulkCopyTimeout = Timeout;
 			return copy;

--- a/Rhino.Etl.Core/Pipelines/AbstractPipelineExecuter.cs
+++ b/Rhino.Etl.Core/Pipelines/AbstractPipelineExecuter.cs
@@ -27,8 +27,10 @@ namespace Rhino.Etl.Core.Pipelines
                 IEnumerable<Row> enumerablePipeline = PipelineToEnumerable(pipeline, new List<Row>(), translateRows);
                 try
                 {
+					raiseNotifyExecutionStarting();
                     DateTime start = DateTime.Now;
                     ExecutePipeline(enumerablePipeline);
+					raiseNotifyExecutionCompleting();
                     Trace("Completed process {0} in {1}", pipelineName, DateTime.Now - start);
                 }
                 catch (Exception e)
@@ -128,7 +130,33 @@ namespace Rhino.Etl.Core.Pipelines
             }
         }
 
-        /// <summary>
+		///	<summary>
+		///	Occurs when	the	pipeline has been successfully created,	but	before it is executed
+		///	</summary>
+		public event Action<IPipelineExecuter> NotifyExecutionStarting = delegate {	};
+
+		///	<summary>
+		///	Raises the ExecutionStarting event
+		///	</summary>
+		private	void raiseNotifyExecutionStarting()
+		{
+			NotifyExecutionStarting(this);
+		}
+
+		///	<summary>
+		///	Occurs when	the	pipeline has been successfully created,	but	before it is disposed
+		///	</summary>
+		public event Action<IPipelineExecuter> NotifyExecutionCompleting = delegate	{ };
+
+		///	<summary>
+		///	Raises the ExecutionCompleting event
+		///	</summary>
+		private	void raiseNotifyExecutionCompleting()
+		{
+			NotifyExecutionCompleting(this);
+		}
+
+		///	<summary>
         /// Add a decorator to the enumerable for additional processing
         /// </summary>
         /// <param name="operation">The operation.</param>

--- a/Rhino.Etl.Tests/Branches/BranchesEventsFixture.cs
+++ b/Rhino.Etl.Tests/Branches/BranchesEventsFixture.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Rhino.Etl.Core;
+using Rhino.Etl.Core.Operations;
+using Rhino.Mocks;
+using Xunit;
+
+namespace Rhino.Etl.Tests.Branches
+{
+	public class BranchEventsFixture
+	{
+
+		public Action<IOperation, Row> processAction = delegate	{ };
+		public Action<IOperation> finishedAction = delegate	{ };
+
+		[Fact]
+		public void	CanPassOnAddedProcessedEvents()
+		{
+			//Arrange
+			var	branching =	new	TestAbstractBranchingOperation();
+			const int nOps = 5;
+			var	ops	= new IOperation[nOps];
+			for	(var i = 0;	i <	nOps; i++)
+			{
+				ops[i] = MockRepository.GenerateMock<IOperation>();
+				ops[i].Expect(x	=> x.OnRowProcessed	+= processAction);
+				branching.Add(ops[i]);
+			}
+
+			//Act
+			branching.OnRowProcessed +=	processAction;
+
+			//Assert
+			foreach(var	op in ops)
+				op.VerifyAllExpectations();
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnRowProcessed",	BindingFlags.Static	| BindingFlags.Instance	| BindingFlags.NonPublic);
+			Assert.Equal(2,	((Delegate)(handlerInfos.GetValue(branching))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnAddedFinishedEvents()
+		{
+			var	branching =	new	TestAbstractBranchingOperation();
+			const int nOps = 5;
+			var	ops	= new IOperation[nOps];
+			for	(var i = 0;	i <	nOps; i++)
+			{
+				ops[i] = MockRepository.GenerateMock<IOperation>();
+				ops[i].Expect(x	=> x.OnFinishedProcessing += finishedAction);
+				branching.Add(ops[i]);
+			}
+
+			branching.OnFinishedProcessing += finishedAction;
+
+			foreach	(var op	in ops)
+				op.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnFinishedProcessing", BindingFlags.Static |	BindingFlags.Instance |	BindingFlags.NonPublic);
+			Assert.Equal(2,	((Delegate)(handlerInfos.GetValue(branching))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnRemovedProcessedEvents()
+		{
+			//Arrange
+			var	branching =	new	TestAbstractBranchingOperation();
+			const int nOps = 5;
+			var	ops	= new IOperation[nOps];
+			for	(var i = 0;	i <	nOps; i++)
+			{
+				ops[i] = MockRepository.GenerateMock<IOperation>();
+				ops[i].Expect(x	=> x.OnRowProcessed	+= processAction);
+				ops[i].Expect(x	=> x.OnRowProcessed	-= processAction);
+				branching.Add(ops[i]);
+			}
+
+			//Act
+			branching.OnRowProcessed +=	processAction;
+			branching.OnRowProcessed -=	processAction;
+
+			//Assert
+			foreach	(var op	in ops)
+				op.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnRowProcessed",	BindingFlags.Static	| BindingFlags.Instance	| BindingFlags.NonPublic);
+			Assert.Equal(1,	((Delegate)(handlerInfos.GetValue(branching))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnRemovedFinishedEvents()
+		{
+			var	branching =	new	TestAbstractBranchingOperation();
+			const int nOps = 5;
+			var	ops	= new IOperation[nOps];
+			for	(var i = 0;	i <	nOps; i++)
+			{
+				ops[i] = MockRepository.GenerateMock<IOperation>();
+				ops[i].Expect(x	=> x.OnFinishedProcessing += finishedAction);
+				ops[i].Expect(x	=> x.OnFinishedProcessing -= finishedAction);
+				branching.Add(ops[i]);
+			}
+
+			branching.OnFinishedProcessing += finishedAction;
+			branching.OnFinishedProcessing -= finishedAction;
+
+			foreach	(var op	in ops)
+				op.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnFinishedProcessing", BindingFlags.Static |	BindingFlags.Instance |	BindingFlags.NonPublic);
+			Assert.Equal(1,	((Delegate)(handlerInfos.GetValue(branching))).GetInvocationList().Length);
+		}
+	}
+
+	public class TestAbstractBranchingOperation	: AbstractBranchingOperation
+	{
+		public override	IEnumerable<Row> Execute(IEnumerable<Row> rows)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Rhino.Etl.Tests/EtlProcessEventsFixture.cs
+++ b/Rhino.Etl.Tests/EtlProcessEventsFixture.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Rhino.Etl.Core;
+using Rhino.Etl.Core.Operations;
+using Rhino.Etl.Core.Pipelines;
+using Xunit;
+
+namespace Rhino.Etl.Tests
+{
+	public class PipelineEventsFixture
+	{
+
+		[Fact]
+		public void	RaiseEventsWhenPipelineExecuted()
+		{
+			//Arrange
+			var	startingCalled = 0;
+			var	completingCalled = 0;
+			var	pipeline = new TestPipelineExecuter();
+			pipeline.NotifyExecutionStarting +=	delegate { startingCalled += 1;	};
+			pipeline.NotifyExecutionCompleting += delegate { completingCalled += 1;	};
+
+			//Act
+			pipeline.Execute("Test", new IOperation[0],	rows =>	rows);
+
+			//Assert);
+			Assert.Equal(1,	startingCalled);
+			Assert.Equal(1,	completingCalled);
+		}
+	}
+
+	public class TestPipelineExecuter :	AbstractPipelineExecuter
+	{
+		protected override IEnumerable<Row>	DecorateEnumerableForExecution(IOperation operation, IEnumerable<Row> enumerator)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Rhino.Etl.Tests/Joins/JoinsEventsFixture.cs
+++ b/Rhino.Etl.Tests/Joins/JoinsEventsFixture.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Rhino.Etl.Core;
+using Rhino.Etl.Core.Operations;
+using Rhino.Mocks;
+using Xunit;
+
+namespace Rhino.Etl.Tests.Joins
+{
+	public class JoinEventsFixture
+	{
+
+		public Action<IOperation, Row> processAction = delegate	{ };
+		public Action<IOperation> finishedAction = delegate	{ };
+
+		[Fact]
+		public void	CanPassOnAddedProcessedEvents()
+		{
+			//Arrange
+			var	join = new TestAbstractJoinOperation();
+			var	op1	= MockRepository.GenerateMock<IOperation>();
+			var	op2	= MockRepository.GenerateMock<IOperation>();
+			join.Left(op1).Right(op2);
+
+			op1.Expect(x =>	x.OnRowProcessed +=	processAction);
+			op2.Expect(x =>	x.OnRowProcessed +=	processAction);
+
+			//Act
+			join.OnRowProcessed	+= processAction;
+
+			//Assert
+			op1.VerifyAllExpectations();
+			op2.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnRowProcessed",	BindingFlags.Static	| BindingFlags.Instance	| BindingFlags.NonPublic);
+			Assert.Equal(2,	((Delegate)(handlerInfos.GetValue(join))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnAddedFinishedEvents()
+		{
+			var	join = new TestAbstractJoinOperation();
+			var	op1	= MockRepository.GenerateMock<IOperation>();
+			var	op2	= MockRepository.GenerateMock<IOperation>();
+			join.Left(op1).Right(op2);
+
+			op1.Expect(x =>	x.OnFinishedProcessing += finishedAction);
+			op2.Expect(x =>	x.OnFinishedProcessing += finishedAction);
+
+			join.OnFinishedProcessing += finishedAction;
+
+			op1.VerifyAllExpectations();
+			op2.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnFinishedProcessing", BindingFlags.Static |	BindingFlags.Instance |	BindingFlags.NonPublic);
+			Assert.Equal(2,	((Delegate)(handlerInfos.GetValue(join))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnRemovedProcessedEvents()
+		{
+			//Arrange
+			var	join = new TestAbstractJoinOperation();
+			var	op1	= MockRepository.GenerateMock<IOperation>();
+			var	op2	= MockRepository.GenerateMock<IOperation>();
+			join.Left(op1).Right(op2);
+
+			op1.Expect(x =>	x.OnRowProcessed +=	processAction);
+			op1.Expect(x =>	x.OnRowProcessed -=	processAction);
+			op2.Expect(x =>	x.OnRowProcessed +=	processAction);
+			op2.Expect(x =>	x.OnRowProcessed -=	processAction);
+
+			//Act
+			join.OnRowProcessed	+= processAction;
+			join.OnRowProcessed	-= processAction;
+
+			//Assert
+			op1.VerifyAllExpectations();
+			op2.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnRowProcessed",	BindingFlags.Static	| BindingFlags.Instance	| BindingFlags.NonPublic);
+			Assert.Equal(1,	((Delegate)(handlerInfos.GetValue(join))).GetInvocationList().Length);
+		}
+
+		[Fact]
+		public void	CanPassOnRemovedFinishedEvents()
+		{
+			var	join = new TestAbstractJoinOperation();
+			var	op1	= MockRepository.GenerateMock<IOperation>();
+			var	op2	= MockRepository.GenerateMock<IOperation>();
+			join.Left(op1).Right(op2);
+
+			op1.Expect(x =>	x.OnFinishedProcessing += finishedAction);
+			op1.Expect(x =>	x.OnFinishedProcessing -= finishedAction);
+			op2.Expect(x =>	x.OnFinishedProcessing += finishedAction);
+			op2.Expect(x =>	x.OnFinishedProcessing -= finishedAction);
+
+			join.OnFinishedProcessing += finishedAction;
+			join.OnFinishedProcessing -= finishedAction;
+
+			op1.VerifyAllExpectations();
+			op2.VerifyAllExpectations();
+
+			var	handlerInfos = typeof(AbstractOperation).GetField("OnFinishedProcessing", BindingFlags.Static |	BindingFlags.Instance |	BindingFlags.NonPublic);
+			Assert.Equal(1,	((Delegate)(handlerInfos.GetValue(join))).GetInvocationList().Length);
+		}
+	}
+
+	public class TestAbstractJoinOperation : JoinOperation
+	{
+		public override	IEnumerable<Row> Execute(IEnumerable<Row> rows)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected override Row MergeRows(Row leftRow, Row rightRow)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected override void	SetupJoinConditions()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
+++ b/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
@@ -103,6 +103,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="Branches\AbstractFibonacciBranchingProcess.cs" />
+    <Compile Include="Branches\BranchesEventsFixture.cs" />
     <Compile Include="Branches\MultiThreadedBranchesWithMultiThreadPipeline.cs" />
     <Compile Include="Branches\MultiThreadedBranchesWithSingleThreadPipeline.cs" />
     <Compile Include="Branches\MultiThreadedWithMultiThreadPipelineFibonacciBranchingProcess.cs" />
@@ -121,6 +122,7 @@
     <Compile Include="Errors\ErrorsFixture.cs" />
     <Compile Include="Errors\ErrorsProcess.cs" />
     <Compile Include="Errors\ThrowingOperation.cs" />
+    <Compile Include="EtlProcessEventsFixture.cs" />
     <Compile Include="Fibonacci\Batch\BatchFibonacci.cs" />
     <Compile Include="Fibonacci\Batch\BatchFibonacciToDatabase.cs" />
     <Compile Include="Fibonacci\Batch\BatchFibonacciToDatabaseFromConnectionStringSettings.cs" />
@@ -155,6 +157,7 @@
     <Compile Include="Joins\InnerJoinUsersToPeopleByEmail.cs" />
     <Compile Include="Joins\JoinFixture.cs" />
     <Compile Include="Joins\JoinInProcessFixture.cs" />
+    <Compile Include="Joins\JoinsEventsFixture.cs" />
     <Compile Include="Joins\LeftJoinUsersToPeopleByEmail.cs" />
     <Compile Include="Joins\RightJoinUsersToPeopleByEmail.cs" />
     <Compile Include="Joins\TrivialUsersToPeopleJoinProcess.cs" />
@@ -174,7 +177,6 @@
     <Compile Include="LoadTest\UpperCaseUserNames.cs" />
     <Compile Include="OutputCommandFixture.cs" />
     <Compile Include="Branches\BranchesFixture.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RowTest.cs" />
     <Compile Include="SingleThreadedPipelineExecuterTest.cs" />
     <Compile Include="SqlBatchOperationFixture.cs" />

--- a/Rhino.Etl.Tests/SqlBulkInsertOperationFixture.cs
+++ b/Rhino.Etl.Tests/SqlBulkInsertOperationFixture.cs
@@ -1,3 +1,8 @@
+using System.Configuration;
+using System.Data.SqlClient;
+using Rhino.Etl.Core.Operations;
+using Rhino.Mocks;
+
 namespace Rhino.Etl.Tests
 {
     using System;
@@ -36,4 +41,26 @@ namespace Rhino.Etl.Tests
             AssertFibonacciTableEmpty();
         }
     }
+
+	public class BulkInsertNotificationTests
+	{
+		[Fact]
+		public void	CheckNotifyBatchSizeTakenFromBatchSize()
+		{
+			FibonacciBulkInsert	fibonacci =	new	FibonacciBulkInsert();
+			fibonacci.BatchSize	= 50;
+
+			Assert.Equal(fibonacci.BatchSize, fibonacci.NotifyBatchSize);
+		}
+
+		[Fact]
+		public void	CheckNotifyBatchSizeNotTakenFromBatchSize()
+		{
+			FibonacciBulkInsert	fibonacci =	new	FibonacciBulkInsert();
+			fibonacci.BatchSize	= 50;
+			fibonacci.NotifyBatchSize =	25;
+
+			Assert.Equal(25, fibonacci.NotifyBatchSize);
+		}
+	}
 }


### PR DESCRIPTION
Hi,

Finally got round to sorting out the line-ending mess on the previous pull request, basically by re-applying the changes on a fresh fork from today.  Here's what it comprises:
- GatedThreadSafeEnumerator now public so it can be used by other classes;
- Branching operation passes on event registrations to the branch processes;
- Join operation passes on event registrations to the joined processes;
- Partial process operation passes on prepareForExecution to contained operations
- SqlBulkInsertOperation notifies of progress; controllable batch size.
- Pipeline executer raises events at start of execution (once pipeline has been constructed)
  and on completion of execution (before disposing the pipeline)

Hope it's all clear, let me know if any problems

Thanks,

Miles
