### PR TITLE
Update SqlBulkInsertOperation to use NotifyBatchSize instead of notifyBa...

### DIFF
--- a/Rhino.Etl.Core/Operations/SqlBulkInsertOperation.cs
+++ b/Rhino.Etl.Core/Operations/SqlBulkInsertOperation.cs
@@ -280,7 +280,7 @@ namespace Rhino.Etl.Core.Operations
             {
                 copy.ColumnMappings.Add(pair.Key, pair.Value);
             }
-            copy.NotifyAfter = notifyBatchSize;
+            copy.NotifyAfter = NotifyBatchSize;
             copy.SqlRowsCopied += onSqlRowsCopied;
             copy.DestinationTableName = TargetTable;
             copy.BulkCopyTimeout = Timeout;


### PR DESCRIPTION
For your consideration: Use the NotifyBatchSize property instead of private variable notifyBatchSize so that it falls back on batchSize if notifyBatchSize isn't provided.  This is so OnSqlRowsCopied works correctly if only batchSize is available.
