### PR TITLE
Added an aggregation operation that assumes a sorted rowset.

### DIFF
--- a/Rhino.Etl.Core/Operations/AbstractSortedAggregationOperation.cs
+++ b/Rhino.Etl.Core/Operations/AbstractSortedAggregationOperation.cs
@@ -1,0 +1,42 @@
+﻿namespace Rhino.Etl.Core.Operations
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An aggregation operation, handles all the backend stuff of the aggregation,
+    /// leaving client code just the accumulation process. Assumes a sorted rowset
+    /// so that we can return early instead of having to accumulate all rows.
+    /// </summary>
+    public abstract class AbstractSortedAggregationOperation : AbstractAggregationOperation
+    {
+        /// <summary>
+        /// Executes this operation
+        /// </summary>
+        /// <param name="rows">The pre-sorted rows.</param>
+        /// <returns></returns>
+        public override IEnumerable<Row> Execute(IEnumerable<Row> rows)
+        {
+            ObjectArrayKeys previousKey = null;
+            var aggregate = new Row();
+            var groupBy = GetColumnsToGroupBy();
+
+            foreach (var row in rows)
+            {
+                var key = row.CreateKey(groupBy);
+
+                if (previousKey != null && !previousKey.Equals(key))
+                {
+                    FinishAggregation(aggregate);
+                    yield return aggregate;
+                    aggregate = new Row();
+                }
+
+                Accumulate(row, aggregate);
+                previousKey = key;
+            }
+
+            FinishAggregation(aggregate);
+            yield return aggregate;
+        }
+    }
+}

--- a/Rhino.Etl.Core/Rhino.Etl.Core.csproj
+++ b/Rhino.Etl.Core/Rhino.Etl.Core.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Infrastructure\SqlCommandSet.cs" />
     <Compile Include="Infrastructure\Use.cs" />
     <Compile Include="Operations\AbstractBranchingOperation.cs" />
+    <Compile Include="Operations\AbstractSortedAggregationOperation.cs" />
     <Compile Include="Operations\BranchingOperation.cs" />
     <Compile Include="Operations\JoinType.cs" />
     <Compile Include="Operations\MultiThreadedBranchingOperation.cs" />

--- a/Rhino.Etl.Tests/Aggregation/AggregationFixture.cs
+++ b/Rhino.Etl.Tests/Aggregation/AggregationFixture.cs
@@ -36,5 +36,25 @@ namespace Rhino.Etl.Tests.Aggregation
                 Assert.Equal(6, items[2]["cost"]);
             }
         }
+
+        [Fact]
+        public void SortedAggregateCostPerProduct()
+        {
+            using (SortedCostPerProductAggregation aggregation = new SortedCostPerProductAggregation())
+            {
+                IEnumerable<Row> result = aggregation.Execute(rows);
+                List<Row> items = new List<Row>(result);
+                Assert.Equal(4, items.Count);
+                Assert.Equal("milk", items[0]["name"]);
+                Assert.Equal("sugar", items[1]["name"]);
+                Assert.Equal("coffee", items[2]["name"]);
+                Assert.Equal("sugar", items[3]["name"]);
+
+                Assert.Equal(30, items[0]["cost"]);
+                Assert.Equal(25, items[1]["cost"]);
+                Assert.Equal(6, items[2]["cost"]);
+                Assert.Equal(3, items[3]["cost"]);
+            }
+        }
     }
 }

--- a/Rhino.Etl.Tests/Aggregation/SortedCostPerProductAggregation.cs
+++ b/Rhino.Etl.Tests/Aggregation/SortedCostPerProductAggregation.cs
@@ -1,0 +1,26 @@
+﻿namespace Rhino.Etl.Tests.Aggregation
+{
+    using Core;
+    using Rhino.Etl.Core.Operations;
+
+    public class SortedCostPerProductAggregation : AbstractSortedAggregationOperation
+    {
+        /// <summary>
+        /// Accumulate the current row to the current aggregation
+        /// </summary>
+        /// <param name="row">The row.</param>
+        /// <param name="aggregate">The aggregate.</param>
+        protected override void Accumulate(Row row, Row aggregate)
+        {
+            aggregate["name"] = row["name"];
+            if (aggregate["cost"] == null)
+                aggregate["cost"] = 0;
+            aggregate["cost"] = ((int)aggregate["cost"]) + ((int)row["price"]);
+        }
+
+        protected override string[] GetColumnsToGroupBy()
+        {
+            return new string[] { "name" };
+        }
+    }
+}

--- a/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
+++ b/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Aggregation\BaseDslTest.cs" />
     <Compile Include="Aggregation\CostPerProductAggregation.cs" />
     <Compile Include="Aggregation\RowCount.cs" />
+    <Compile Include="Aggregation\SortedCostPerProductAggregation.cs" />
     <Compile Include="BaseFibonacciTest.cs" />
     <None Include="Dsl\Aggregate.boo">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
For cases in which we know the rows have been sorted in advance, this operation yield returns the current aggregate as soon as a change in keys is detected. This avoids having to load aggregate all rows before returning.
