### PR TITLE
Support ADO.NET compatible provider names in connection settings

### DIFF
--- a/Rhino.Etl.Tests/Infrastructure/UseFixture.cs
+++ b/Rhino.Etl.Tests/Infrastructure/UseFixture.cs
@@ -1,0 +1,47 @@
+﻿namespace Rhino.Etl.Tests.Infrastructure
+{
+    using System.Configuration;
+    using System.Data;
+    using System.Data.SqlClient;
+    using Rhino.Etl.Core.Infrastructure;
+    using Xunit;
+
+    public class UseFixture
+    {
+        [Fact]
+        public void SupportsAssemblyQualifiedConnectionTypeNameAsProviderNameInConnectionStringSettings()
+        {
+            string connectionString = ConfigurationManager.ConnectionStrings["test"].ConnectionString;
+            ConnectionStringSettings connectionStringSettings = new ConnectionStringSettings("test2", connectionString, typeof(SqlConnection).AssemblyQualifiedName);
+
+            using (IDbConnection connection = Use.Connection(connectionStringSettings))
+            {
+                Assert.NotNull(connection);
+            }
+        }
+ 
+        [Fact]
+        public void SupportsProviderNameInConnectionStringSettings()
+        {
+            string connectionString = ConfigurationManager.ConnectionStrings["test"].ConnectionString;
+            ConnectionStringSettings connectionStringSettings = new ConnectionStringSettings("test2", connectionString, "System.Data.SqlClient");
+
+            using (IDbConnection connection = Use.Connection(connectionStringSettings))
+            {
+                Assert.NotNull(connection);
+            }
+        }
+
+        [Fact]
+        public void UsesSqlClientAsDefaultProviderInConnectionStringSettings()
+        {
+            string connectionString = ConfigurationManager.ConnectionStrings["test"].ConnectionString;
+            ConnectionStringSettings connectionStringSettings = new ConnectionStringSettings("test2", connectionString);
+
+            using (IDbConnection connection = Use.Connection(connectionStringSettings))
+            {
+                Assert.NotNull(connection);
+            }
+        }
+    }
+}

--- a/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
+++ b/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="BaseUserToPeopleTest.cs" />
     <Compile Include="Fibonacci\Output\Should.cs" />
     <Compile Include="InformationFixture.cs" />
+    <Compile Include="Infrastructure\UseFixture.cs" />
     <Compile Include="Integration\UsersToPeopleFromConnectionStringSettings.cs" />
     <Compile Include="Integration\DatabaseToDatabaseWithTransformations.cs" />
     <Compile Include="Integration\ReadUsers.cs" />


### PR DESCRIPTION
Rhino-Etl expects assembly qualified type names of connection classes in the ConnectionStringSettings.ProviderName property. This deviates from regular ADO.NET usage and causes issues if connection strings in the configuration file are used by non Rhino-Etl code.

Rather than specifying in the app.config file:

```
<add name="test"
   connectionString="Data Source=.\SQLExpress;Initial Catalog=test;Integrated Security=SSPI;Timeout=30;"
   providerName="System.Data.SqlClient.SqlConnection, System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
```

The following should be sufficient:

```
<add name="test"
   connectionString="Data Source=.\SQLExpress;Initial Catalog=test;Integrated Security=SSPI;Timeout=30;"
   providerName="System.Data.SqlClient"/>
```
