### PR TITLE
Support custom row key comparers

### DIFF
--- a/Rhino.Etl.Core/QuackingDictionary.cs
+++ b/Rhino.Etl.Core/QuackingDictionary.cs
@@ -15,6 +15,20 @@ namespace Rhino.Etl.Core
     public class QuackingDictionary : IDictionary, IQuackFu
     {
         /// <summary>
+        /// Default value for the Comparer property.
+        /// Defines how keys are compared (case sensitivity, hashing algorithm, etc.)
+        /// </summary>
+        public static StringComparer DefaultComparer { get; set; }
+
+        /// <summary>
+        /// Initialization for static members/properties
+        /// </summary>
+        static QuackingDictionary()
+        {
+            DefaultComparer = StringComparer.InvariantCultureIgnoreCase;
+        }
+
+        /// <summary>
         /// The inner items collection
         /// </summary>
         protected IDictionary items;
@@ -25,6 +39,11 @@ namespace Rhino.Etl.Core
         protected string lastAccess;
 
         private bool throwOnMissing = false;
+
+        /// <summary>
+        /// Defines how keys are compared (case sensitivity, hashing algorithm, etc.)
+        /// </summary>
+        protected StringComparer Comparer { get; set; }
 
         /// <summary>
         /// Set the flag to thorw if key not found.
@@ -38,12 +57,24 @@ namespace Rhino.Etl.Core
         /// Initializes a new instance of the <see cref="QuackingDictionary"/> class.
         /// </summary>
         /// <param name="items">The items.</param>
-        public QuackingDictionary(IDictionary items)
+        /// <param name="comparer">Defines key equality</param>
+        public QuackingDictionary(IDictionary items, StringComparer comparer)
         {
+            Comparer = comparer;
+
             if (items != null)
-                this.items = new Hashtable(items, StringComparer.InvariantCultureIgnoreCase);
+                this.items = new Hashtable(items, Comparer);
             else
-                this.items = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+                this.items = new Hashtable(Comparer);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuackingDictionary"/> class.
+        /// </summary>
+        /// <param name="items">The items.</param>
+        public QuackingDictionary(IDictionary items)
+            : this(items, DefaultComparer)
+        {
         }
 
 

--- a/Rhino.Etl.Core/Row.cs
+++ b/Rhino.Etl.Core/Row.cs
@@ -25,8 +25,17 @@ namespace Rhino.Etl.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="Row"/> class.
         /// </summary>
+        /// <param name="comparer">Defines key equality</param>
+        public Row(StringComparer comparer)
+            : base(new Hashtable(), comparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Row"/> class.
+        /// </summary>
         public Row()
-            : base(new Hashtable(StringComparer.InvariantCultureIgnoreCase))
+            : base(new Hashtable())
         {
         }
 
@@ -34,8 +43,9 @@ namespace Rhino.Etl.Core
         /// Initializes a new instance of the <see cref="Row"/> class.
         /// </summary>
         /// <param name="itemsToClone">The items to clone.</param>
-        protected Row(IDictionary itemsToClone)
-            : base(new Hashtable(itemsToClone, StringComparer.InvariantCultureIgnoreCase))
+        /// <param name="comparer">Defines key equality</param>
+        protected Row(IDictionary itemsToClone, StringComparer comparer)
+            : base(itemsToClone, comparer)
         {
         }
 
@@ -46,7 +56,7 @@ namespace Rhino.Etl.Core
         /// <param name="source">The source row.</param>
         public void Copy(IDictionary source)
         {
-            items = new Hashtable(source, StringComparer.InvariantCultureIgnoreCase);
+            items = new Hashtable(source, Comparer);
         }
 
         /// <summary>
@@ -72,7 +82,7 @@ namespace Rhino.Etl.Core
         /// <returns></returns>
         public Row Clone()
         {
-            Row row = new Row(this);
+            Row row = new Row(this, Comparer);
             return row;
         }
 
@@ -85,7 +95,10 @@ namespace Rhino.Etl.Core
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(Row other)
         {
-            if(Columns.SequenceEqual(other.Columns, StringComparer.InvariantCultureIgnoreCase) == false)
+            if (!Comparer.Equals(other.Comparer))
+                return false;
+
+            if(Columns.SequenceEqual(other.Columns, Comparer) == false)
                 return false;
 
             foreach (var key in items.Keys)

--- a/Rhino.Etl.Tests/RowTest.cs
+++ b/Rhino.Etl.Tests/RowTest.cs
@@ -45,7 +45,33 @@ namespace Rhino.Etl.Tests
             Row second = new Row();
             second["a"] = 1;
 
+            Row third = second.Clone();
+            
+            Row fourth = new Row();
+            fourth.Copy(third);
+
             Assert.True(first.Equals(second));
+            Assert.True(first.Equals(third));
+            Assert.True(first.Equals(fourth));
+        }
+
+        [Fact]
+        public void Should_respect_stringcomparer_specification()
+        {
+            Row first = new Row(StringComparer.Ordinal);
+            first["A"] = 1;
+
+            Row second = new Row(StringComparer.Ordinal);
+            second["a"] = 1;
+
+            Row third = second.Clone();
+
+            Row fourth = new Row();
+            fourth.Copy(second);
+
+            Assert.False(first.Equals(second));
+            Assert.False(first.Equals(third));
+            Assert.False(first.Equals(fourth));
         }
 
         [Theory]


### PR DESCRIPTION
The default key comparer used by QuackingDictionary, and its child class Row, can't currently be changed.

My changes allow for a custom StringComparer to be specified upon instantiation. It is then preserved over row cloning and copying.
This can be useful in various scenarios:
- If case sensitivity is required for keys
- If better performance is needed (my particular usecase)

My commit should be entirely backwards compatible and doesn't change existing behaviour. Nevertheless, for an easy performance improvement accross all users of the library, at very little cost, I would suggest changing the default value for QuackingDictionary.DefaultComparer to StringComparer.OrdinalIgnoreCase after my changes are pulled in. This should be _nearly_ identical except in very remote corner cases, and tests on my computer have shown that it is up to 10x faster for hashing (which happens **a lot** in Rhino ETL applications).
