### PR TITLE
Bug Fix for issue: JoinOperation errors are not propagated to the main EtlProcess

### DIFF
--- a/Rhino.Etl.Core/Operations/AbstractJoinOperation.cs
+++ b/Rhino.Etl.Core/Operations/AbstractJoinOperation.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rhino.Etl.Core.Operations
+{
+    /// <summary>
+    /// Perform a join between two sources.
+    /// </summary>
+    public abstract class AbstractJoinOperation : AbstractOperation
+    {
+        /// <summary>
+        /// The left process
+        /// </summary>
+        protected readonly PartialProcessOperation left = new PartialProcessOperation();
+
+        /// <summary>
+        /// The rigth process
+        /// </summary>
+        protected readonly PartialProcessOperation right = new PartialProcessOperation();
+
+        /// <summary>
+        /// Is left registered?
+        /// </summary>
+        protected bool leftRegistered = false;
+
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        protected virtual void Initialize()
+        {
+        }
+
+        /// <summary>
+        /// Called when a row on the right side was filtered by
+        /// the join condition, allow a derived class to perform
+        /// logic associated to that, such as logging
+        /// </summary>
+        protected virtual void RightOrphanRow(Row row)
+        {
+        }
+
+        /// <summary>
+        /// Called when a row on the left side was filtered by
+        /// the join condition, allow a derived class to perform
+        /// logic associated to that, such as logging
+        /// </summary>
+        /// <param name="row">The row.</param>
+        protected virtual void LeftOrphanRow(Row row)
+        {
+        }
+
+        /// <summary>
+        /// Check left/right branches are not null
+        /// </summary>
+        protected void PrepareForJoin()
+        {
+            Initialize();
+            Guard.Against(left == null, "Left branch of a join cannot be null");
+            Guard.Against(right == null, "Right branch of a join cannot be null");
+        }
+
+        /// <summary>
+        /// Initializes this instance
+        /// </summary>
+        /// <param name="pipelineExecuter">The current pipeline executer.</param>
+        public override void PrepareForExecution(IPipelineExecuter pipelineExecuter)
+        {
+            left.PrepareForExecution(pipelineExecuter);
+            right.PrepareForExecution(pipelineExecuter);
+        }
+
+        /// <summary>
+        /// Gets all errors that occured when running this operation
+        /// </summary>
+        /// <returns></returns>
+        public override IEnumerable<Exception> GetAllErrors()
+        {
+            foreach (Exception error in left.GetAllErrors())
+            {
+                yield return error;
+            }
+            foreach (Exception error in right.GetAllErrors())
+            {
+                yield return error;
+            }
+            foreach (Exception error in Errors)
+            {
+                yield return error;
+            }
+        }
+
+        /// <summary>
+        /// Merges the two rows into a single row
+        /// </summary>
+        /// <param name="leftRow">The left row.</param>
+        /// <param name="rightRow">The right row.</param>
+        /// <returns></returns>
+        protected abstract Row MergeRows(Row leftRow, Row rightRow);
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            left.Dispose();
+            right.Dispose();
+        }
+    }
+}

--- a/Rhino.Etl.Core/Rhino.Etl.Core.csproj
+++ b/Rhino.Etl.Core/Rhino.Etl.Core.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Infrastructure\SqlCommandSet.cs" />
     <Compile Include="Infrastructure\Use.cs" />
     <Compile Include="Operations\AbstractBranchingOperation.cs" />
+    <Compile Include="Operations\AbstractJoinOperation.cs" />
     <Compile Include="Operations\AbstractSortedAggregationOperation.cs" />
     <Compile Include="Operations\BranchingOperation.cs" />
     <Compile Include="Operations\JoinType.cs" />

--- a/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
+++ b/Rhino.Etl.Tests/Rhino.Etl.Tests.csproj
@@ -232,6 +232,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
     <Service Include="{B4F97281-0DBD-4835-9ED8-7DFB966E87FF}" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request proposes to fix this issue: https://github.com/hibernating-rhinos/rhino-etl/issues/18
In addition, it creates a common AbstractJoinOperation shared by JoinOperation and NestedLoopsJoinOperation. So, similar code is not duplicated.
Thanks in advance for your feedback!