### PR TITLE
Prepare the database before loading rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Rhino.Etl.nuspec
 /Rhino-Etl-Cmd.nuspec
 Tools/xUnit/Aggregate.*
 Tools/xUnit/users.txt
+.vs

--- a/Rhino.Etl.Core/Operations/OutputCommandOperation.cs
+++ b/Rhino.Etl.Core/Operations/OutputCommandOperation.cs
@@ -39,6 +39,7 @@ namespace Rhino.Etl.Core.Operations
             using (IDbConnection connection = Use.Connection(ConnectionStringSettings))
             using (IDbTransaction transaction = BeginTransaction(connection))
             {
+                PrepareDatabase(connection, transaction);
                 foreach (Row row in new SingleRowEventRaisingEnumerator(this, rows))
                 {
                     using (IDbCommand cmd = connection.CreateCommand())
@@ -71,5 +72,14 @@ namespace Rhino.Etl.Core.Operations
         /// <param name="cmd">The command.</param>
         /// <param name="row">The row.</param>
         protected abstract void PrepareCommand(IDbCommand cmd, Row row);
+
+        /// <summary>
+        /// Prepares the database before loading rows.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="transaction">The transaction.</param>
+        protected virtual void PrepareDatabase(IDbConnection connection, IDbTransaction transaction)
+        {
+        }
     }
 }


### PR DESCRIPTION
Adds a new virtual method PrepareDatabase to the class OutputCommandOperation. This method can be overridden in a derived class to add some code for preparing the database (deleting or disabling some rows) before loading rows.